### PR TITLE
Revert back to Gold color in Minecraft palette

### DIFF
--- a/palettes/Minecraft-Text-Colors.gpl
+++ b/palettes/Minecraft-Text-Colors.gpl
@@ -26,7 +26,7 @@ Columns: 17
   0  42  42	Dark Aqua BG
  42   0   0	Dark Red BG
  42   0  42	Dark Purple BG
- 64  42   0	Gold BG
+ 42  42   0	Gold BG
  42  42  42	Gray BG
  21  21  21	Dark Gray BG
  21  21  63	Blue BG


### PR DESCRIPTION
> * Changed the gold background color to the Bedrock Edition variant.

I don't know _why_ you changed the gold background color to the one from Bedrock Edition, but unless you want two palettes, I suggest to go with the **Java Edition** color like in my original PR.