### PR TITLE
Do NOT use the fandom wiki. the creators are trying to ditch the minecraft fandom wiki in favor of minecraft.wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Sources for palettes in this collection:
 * MindMup
     * <https://www.mindmup.com/>
 * Minecraft
-    * <https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes>
+    * <https://minecraft.wiki/w/Formatting_codes>
 * OnePlus Gallery
     * <https://play.google.com/store/apps/details?id=com.oneplus.gallery>
 * Papyrus (Android app by Steadfast Innovation)

--- a/palettes/Minecraft-Text-Colors.gpl
+++ b/palettes/Minecraft-Text-Colors.gpl
@@ -2,7 +2,7 @@ GIMP Palette
 Name: Minecraft Text Colors
 Columns: 17
 # Colors from the legacy §-based formatting system.
-# https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes
+# https://minecraft.wiki/w/Formatting_codes
   0   0   0	Black
   0   0 170	Dark Blue
   0 170   0	Dark Green


### PR DESCRIPTION
Please change https://minecraft.fandom.com/wiki/Formatting_codes#Color_codes to https://minecraft.wiki/w/Formatting_codes

Fandom is so unreliable and has ads everywhere. Use minecraft.wiki instead of the fandom one.

Thank you.

(also this is the very first pull request I did on GitHub, wooooo)